### PR TITLE
TRITON-2052 sdc-imgadm import should import from any channel by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "smartdc": "git+https://github.com/joyent/node-smartdc.git#4308fd9",
         "manta": "git+https://github.com/joyent/node-manta.git#b277acf",
         "moray": "git+https://github.com/joyent/node-moray.git#b84ef0e",
-        "imgapi-cli": "git+https://github.com/joyent/sdc-imgapi-cli.git#v2.4.1",
+        "imgapi-cli": "git+https://github.com/joyent/sdc-imgapi-cli.git#v2.5.0",
         "bunyan": "1.3.3",
         "assert-plus": "0.1.5",
         "ldapjs": "git+https://github.com/mcavage/node-ldapjs.git#f213b3e",


### PR DESCRIPTION
Actually bump up to the new sdc-imgadm cli