### PR TITLE
TRITON-2128 Update deps/hermes to stop uploading empty log files

### DIFF
--- a/lib/sdc-events.js
+++ b/lib/sdc-events.js
@@ -8,7 +8,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*


### PR DESCRIPTION
The update also brings in commits prior to TRITON-2128. See jira ticket for testing notes.