### PR TITLE
TRITON-2460 sdc-check-amqp does not disconnect cleanly from rabbitmq

### DIFF
--- a/bin/sdc-check-amqp
+++ b/bin/sdc-check-amqp
@@ -1,6 +1,7 @@
 #!/opt/smartdc/sdc/build/node/bin/node --abort-on-uncaught-exception
 /*
  * Copyright (c) 2013 Joyent Inc. All rights reserved.
+ * Copyright 2024 Spearhead Systems SRL.
  *
  * Checks if Rabbitmq is online and properly sending messages through
  */
@@ -62,6 +63,7 @@ conn.on('ready', function () {
     }
 
     function onMessage(message, headers, deliveryInfo, messageObject) {
+        conn.disconnect();
         assert.equal(deliveryInfo.routingKey, 'checkamqp.testing');
         assert.equal(message.pid, process.pid);
         if (timeout) {


### PR DESCRIPTION
There are a lot of these errors in /var/log/rabbit/rabbit.log:

```
=INFO REPORT==== 17-Oct-2024::13:13:44 ===
accepted TCP connection on 0.0.0.0:5672 from 10.99.99.7:51171

=INFO REPORT==== 17-Oct-2024::13:13:44 ===
starting TCP connection <0.17775.0> from 10.99.99.7:51171

=WARNING REPORT==== 17-Oct-2024::13:13:44 ===
exception on TCP connection <0.17775.0> from 10.99.99.7:51171
connection_closed_abruptly

=INFO REPORT==== 17-Oct-2024::13:13:44 ===
closing TCP connection <0.17775.0> from 10.99.99.7:51171
```

A _lot_:

```
[root@1b4d97d3-87a6-43ef-941d-a50485a24341 (ro-1:rabbitmq0) /var/log/rabbitmq]# grep connection_closed_abruptly rabbit.log | wc -l
863943
```

I found two sources of this: `sdc-check-amqp` (which this PR fixes) and `sdc-oneachnode` (haven't found a nice way to fix yet). Once this PR is applied, connections look like this instead:

```
=INFO REPORT==== 17-Oct-2024::13:22:02 ===
accepted TCP connection on 0.0.0.0:5672 from 10.99.99.27:44955

=INFO REPORT==== 17-Oct-2024::13:22:02 ===
starting TCP connection <0.21822.0> from 10.99.99.27:44955

=INFO REPORT==== 17-Oct-2024::13:22:02 ===
closing TCP connection <0.21822.0> from 10.99.99.27:44955
```

`sdc-check-amqp` is called by a default probe in amon.



